### PR TITLE
configuration: Adding configuration file support to store API credentials

### DIFF
--- a/OvhApi/Answer.pm
+++ b/OvhApi/Answer.pm
@@ -129,11 +129,12 @@ sub toString
     }
     else
     {
-        return $self->error;
+        my $queryID = $self->{'response'}->header('X-OVH-QUERYID') || '';
+        return sprintf("%s (Request-ID: %s)", $self->error, $queryID);
     }
 }
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # private part
 
 sub _generateContent
@@ -147,7 +148,7 @@ sub _generateContent
         return { message => 'Internal LWP::UserAgent error : ' . $self->{'response'}->content };
     }
 
-    eval { $content = $Json->decode($self->{'response'}->content); 1; } or do { 
+    eval { $content = $Json->decode($self->{'response'}->content); 1; } or do {
         carp 'Failed to parse JSON content from the answer: ', $self->{'response'}->content;
         return;
     };


### PR DESCRIPTION
- Added configuration file support:
    API credentials can be stored in ovh.conf (current folder, homedir,
    or system-wide)
- Added error handling for missing parameters on calls
- Added error handling when calling API on authenticated routes without consumerKey
- Added usage in README
- Added X-OVH-QUERYID header in error messages